### PR TITLE
Pipeline hardening: icon preflight, checker accuracy, batch export errors, project doctor

### DIFF
--- a/scripts/finalize_svg.py
+++ b/scripts/finalize_svg.py
@@ -34,6 +34,7 @@ Processing options:
 """
 
 import os
+import re
 import sys
 import shutil
 import argparse
@@ -161,6 +162,7 @@ def finalize_project(
         print()
 
     # Step 2: Embed icons
+    icons_residual: dict[str, int] = {}
     if options.get('embed_icons'):
         if not quiet:
             safe_print("[1/4] Embedding icons...")
@@ -168,11 +170,26 @@ def finalize_project(
         for svg_file in svg_final.glob('*.svg'):
             count = embed_icons_in_file(svg_file, icons_dir, dry_run=False, verbose=False)
             icons_count += count
+            residual = len(re.findall(r'<use[^>]*data-icon="', svg_file.read_text(encoding='utf-8')))
+            if residual:
+                icons_residual[svg_file.name] = residual
         if not quiet:
             if icons_count > 0:
                 safe_print(f"      {icons_count} icon(s) embedded")
             else:
                 safe_print("      No icons")
+        if icons_residual:
+            # Unresolved <use data-icon="..."> placeholders hard-fail PPTX
+            # export (SvgNativeConversionError). Fail here instead, with the
+            # full per-file list, so the problem is fixed in one round.
+            safe_print("")
+            safe_print("[ERROR] Unresolved icon placeholders remain after embedding:")
+            for name, count in sorted(icons_residual.items()):
+                safe_print(f"        {name}: {count} unresolved <use data-icon> element(s)")
+            safe_print(
+                "        Fix: correct the icon names, switch the library in "
+                "spec_lock.md, or run scripts/icon_inventory.py missing/fetch"
+            )
 
     # Step 3: Align (slice/meet) and Base64-embed all <image> in one pass.
     # Replaces the former crop-images / fix-aspect / embed-images trio: the
@@ -251,6 +268,11 @@ def finalize_project(
         print()
         print("Next steps:")
         print(f"  python scripts/svg_to_pptx.py \"{project_dir}\"")
+
+    # Unresolved icon placeholders would hard-fail the export step — treat
+    # the finalize run as failed so pipeline scripts stop here.
+    if icons_residual:
+        return False
 
     return True
 

--- a/scripts/icon_inventory.py
+++ b/scripts/icon_inventory.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Icon library inventory for EasySlides.
+
+One command to answer "which icons does this deck need, and does the local
+library actually have them?" — the question the executor currently answers
+by importing a lucide catalog the repo doesn't ship.
+
+Usage:
+    python scripts/icon_inventory.py stats
+        Per-library on-disk counts, plus lucide manifest-vs-disk gap.
+
+    python scripts/icon_inventory.py missing <project_path>
+        Scan <project>/svg_output/*.svg for <use data-icon="..."> refs and
+        report refs whose icon file does not exist. Exit 1 when missing.
+
+    python scripts/icon_inventory.py fetch --lib lucide --names rocket,terminal [--dry-run]
+        Download missing icons from the lucide-static CDN into
+        templates/icons/<lib>/. Explicit, opt-in, network-dependent.
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ICONS_DIR = REPO_ROOT / 'templates' / 'icons'
+MANIFEST_PATH = ICONS_DIR / 'icons_manifest.js'
+LUCIDE_CDN = 'https://unpkg.com/lucide-static@latest/icons/{name}.svg'
+
+
+def libraries_on_disk() -> dict[str, int]:
+    """Library name -> number of .svg files on disk."""
+    out: dict[str, int] = {}
+    if not ICONS_DIR.is_dir():
+        return out
+    for child in sorted(ICONS_DIR.iterdir()):
+        if child.is_dir():
+            out[child.name] = len(list(child.glob('*.svg')))
+    return out
+
+
+def manifest_names() -> set[str]:
+    """Best-effort extraction of the quoted name list in icons_manifest.js."""
+    if not MANIFEST_PATH.exists():
+        return set()
+    text = MANIFEST_PATH.read_text(encoding='utf-8', errors='replace')
+    return set(re.findall(r'"([a-z0-9][a-z0-9._-]*)"', text))
+
+
+def project_icon_refs(project: Path) -> dict[str, set[str]]:
+    """svg files -> set of data-icon refs used (across svg_output/)."""
+    svg_dir = project / 'svg_output'
+    if not svg_dir.is_dir():
+        svg_dir = project
+    refs: dict[str, set[str]] = {}
+    for svg in sorted(svg_dir.glob('*.svg')):
+        text = svg.read_text(encoding='utf-8', errors='replace')
+        for name in re.findall(r'data-icon="([^"]+)"', text):
+            refs.setdefault(name, set()).add(svg.name)
+    return refs
+
+
+def missing_on_disk(refs: set[str]) -> list[str]:
+    """Refs whose icon file does not exist locally."""
+    sys.path.insert(0, str(REPO_ROOT / 'scripts'))
+    from svg_finalize.embed_icons import resolve_icon_path
+    missing = []
+    for name in sorted(refs):
+        path, _base = resolve_icon_path(name, ICONS_DIR)
+        if not path.exists():
+            missing.append(name)
+    return missing
+
+
+def cmd_stats(_args) -> int:
+    disk = libraries_on_disk()
+    print("Icon libraries on disk (templates/icons/):")
+    for lib, count in disk.items():
+        print(f"  {lib:<18} {count:>5} icons")
+    disk_lucide = disk.get('lucide', 0)
+    names = manifest_names()
+    if names and 'lucide' in disk:
+        available = {n for n in names if (ICONS_DIR / 'lucide' / f'{n}.svg').exists()}
+        print(f"\nlucide manifest: {len(names)} names declared, "
+              f"{len(available)} on disk, {len(names - available)} declared-but-missing")
+        print("  -> the manifest promises more than the repo ships; either "
+              "ship the assets, regenerate the manifest from disk, or use "
+              "'fetch' to pull individual icons.")
+        return 1 if len(names - available) > 0 else 0
+    return 0
+
+
+def cmd_missing(args) -> int:
+    project = Path(args.project).resolve()
+    if not project.exists():
+        print(f"[ERROR] project not found: {project}")
+        return 1
+    refs = project_icon_refs(project)
+    if not refs:
+        print("No <use data-icon> references found in svg_output/.")
+        return 0
+    flat = set(refs.keys())
+    missing = missing_on_disk(flat)
+    file_count = len({f for files in refs.values() for f in files})
+    print(f"{len(flat)} distinct icon refs across {file_count} file(s); "
+          f"{len(missing)} missing:")
+    for name in missing:
+        users = sorted(refs.get(name, set()))
+        print(f"  [MISSING] {name}  (used in: {', '.join(users[:3])}"
+              f"{'…' if len(users) > 3 else ''})")
+    if not missing:
+        print("  all refs resolve — OK")
+    return 1 if missing else 0
+
+
+def cmd_fetch(args) -> int:
+    names = [n.strip() for n in args.names.split(',') if n.strip()]
+    target_lib = ICONS_DIR / args.lib
+    if args.lib != 'lucide':
+        print(f"[ERROR] fetch currently supports only --lib lucide "
+              f"(CDN: {LUCIDE_CDN})")
+        return 1
+    target_lib.mkdir(parents=True, exist_ok=True)
+    failures = []
+    fetched = 0
+    for name in names:
+        dest = target_lib / f'{name}.svg'
+        if dest.exists():
+            print(f"  [skip] {name} (already on disk)")
+            continue
+        url = LUCIDE_CDN.format(name=name)
+        if args.dry_run:
+            print(f"  [dry-run] would fetch {url} -> {dest.relative_to(REPO_ROOT)}")
+            continue
+        try:
+            with urllib.request.urlopen(url, timeout=15) as resp:
+                body = resp.read()
+            if b'<svg' not in body:
+                raise ValueError('response is not an SVG document')
+            dest.write_bytes(body)
+            fetched += 1
+            print(f"  [ok] {name} -> {dest.relative_to(REPO_ROOT)}")
+        except Exception as exc:
+            failures.append(name)
+            print(f"  [fail] {name}: {exc}")
+    print(f"\nfetched {fetched}/{len(names)}")
+    return 1 if failures else 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="EasySlides icon inventory.")
+    sub = parser.add_subparsers(dest='command', required=True)
+
+    sub.add_parser('stats', help='Per-library counts + lucide manifest gap.')
+
+    p_missing = sub.add_parser('missing', help='Project refs that lack files.')
+    p_missing.add_argument('project', help='Project directory path.')
+    p_missing.add_argument('--json', action='store_true', dest='as_json')
+
+    p_fetch = sub.add_parser('fetch', help='Download missing lucide icons.')
+    p_fetch.add_argument('--lib', default='lucide')
+    p_fetch.add_argument('--names', required=True,
+                         help='Comma-separated icon names.')
+    p_fetch.add_argument('--dry-run', action='store_true')
+
+    args = parser.parse_args()
+    if args.command == 'stats':
+        sys.exit(cmd_stats(args))
+    if args.command == 'missing':
+        refs = project_icon_refs(Path(args.project).resolve())
+        missing = missing_on_disk(set().union(*refs.values())) if refs else []
+        if args.as_json:
+            print(json.dumps({'missing': missing}, ensure_ascii=False))
+        sys.exit(cmd_missing(args))
+    if args.command == 'fetch':
+        sys.exit(cmd_fetch(args))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/project_doctor.py
+++ b/scripts/project_doctor.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""One-shot project health check for EasySlides decks.
+
+Runs every contract the pipeline enforces — in read-only fashion, before you
+commit to generation or after a failure — and prints a single human-readable
+report: what's fine, what's broken, where to fix it.
+
+Usage:
+    python scripts/project_doctor.py <project_path> [--json]
+
+Checks:
+    1. Structure        deck_plan.json / clarification_request.json /
+                        spec_lock.md / sources/ / svg_output/ present
+    2. Clarification    request exists and is confirmed (pipeline entry gate)
+    3. Deck plan        deck_plan_contract validation (story contract)
+    4. Spec lock        parseable; canvas/colors/typography(body)/page_rhythm
+                        sections present; rhythm keys match deck plan pages
+    5. Icons            every <use data-icon> ref in svg_output/ resolves on
+                        disk; declared library matches the refs in use
+    6. SVG quality      svg_quality_checker run (errors only summarized here)
+
+Exit code 0 when no ERROR-level findings, 1 otherwise. Warnings don't fail.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / 'scripts'))
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+
+class Report:
+    def __init__(self):
+        self.rows: list[tuple[str, str, str]] = []  # (level, check, detail)
+
+    def ok(self, check: str, detail: str = '') -> None:
+        self.rows.append(('OK', check, detail))
+
+    def warn(self, check: str, detail: str) -> None:
+        self.rows.append(('WARN', check, detail))
+
+    def error(self, check: str, detail: str) -> None:
+        self.rows.append(('ERROR', check, detail))
+
+    @property
+    def has_errors(self) -> bool:
+        return any(level == 'ERROR' for level, _, _ in self.rows)
+
+    def print(self) -> None:
+        icon = {'OK': '  ✓ ', 'WARN': '  ⚠ ', 'ERROR': '  ✗ '}
+        last_check = None
+        for level, check, detail in self.rows:
+            if check != last_check:
+                print(f"[{check}]")
+                last_check = check
+            print(f"{icon[level]}{detail}" if detail else f"{icon[level]}{check}")
+        errors = sum(1 for level, _, _ in self.rows if level == 'ERROR')
+        warns = sum(1 for level, _, _ in self.rows if level == 'WARN')
+        print()
+        print(f"Result: {'FAIL' if errors else 'PASS'} "
+              f"({errors} error(s), {warns} warning(s))")
+
+
+def check_structure(project: Path, report: Report) -> None:
+    required = {
+        'deck_plan.json': project / 'deck_plan.json',
+        'spec_lock.md': project / 'spec_lock.md',
+        'sources/': project / 'sources',
+        'svg_output/': project / 'svg_output',
+    }
+    for label, path in required.items():
+        if path.exists():
+            report.ok('structure', f'{label} present')
+        else:
+            report.error('structure', f'{label} missing at {path}')
+    clarify = project / 'clarification_request.json'
+    if clarify.exists():
+        report.ok('structure', 'clarification_request.json present')
+    else:
+        report.warn('structure',
+                    'clarification_request.json missing — pipeline entry gate '
+                    'unrecorded (generation is not authorized without it)')
+
+
+def check_clarification(project: Path, report: Report) -> None:
+    path = project / 'clarification_request.json'
+    if not path.exists():
+        return
+    try:
+        from clarification_gate import require_confirmed
+        request = require_confirmed(path)
+        report.ok('clarification',
+                  f"status={request.get('status')}, route={request.get('route')}")
+    except Exception as exc:
+        report.error('clarification', f'not confirmed: {exc}')
+
+
+def check_deck_plan(project: Path, report: Report) -> int | None:
+    path = project / 'deck_plan.json'
+    if not path.exists():
+        return None
+    try:
+        from deck_plan_contract import validate_deck_plan
+        plan = json.loads(path.read_text(encoding='utf-8'))
+        report_ = validate_deck_plan(plan, repo_root=REPO_ROOT)
+        if report_.get('status') == 'pass':
+            report.ok('deck-plan',
+                      f"contract pass, {report_.get('slide_count')} slides")
+        else:
+            for issue in report_.get('issues', [])[:10]:
+                report.error('deck-plan',
+                             f"{issue.get('code')}: {issue.get('message')} "
+                             f"({issue.get('path') or ''})")
+        return len(plan.get('slides', []))
+    except Exception as exc:
+        report.error('deck-plan', f'validation crashed: {exc}')
+        return None
+
+
+def check_spec_lock(project: Path, report: Report, page_count: int | None) -> None:
+    path = project / 'spec_lock.md'
+    if not path.exists():
+        return
+    try:
+        from update_spec import parse_lock
+        lock = parse_lock(path)
+    except Exception as exc:
+        report.error('spec-lock', f'unparseable: {exc}')
+        return
+    for section in ('canvas', 'colors', 'typography'):
+        if section in lock:
+            report.ok('spec-lock', f'[{section}] present')
+        else:
+            report.error('spec-lock', f'[{section}] section missing')
+    typo = lock.get('typography', {})
+    if not typo.get('body'):
+        report.error('spec-lock',
+                     'typography.body missing — it is the ramp baseline; '
+                     'font-size drift checks cannot work without it')
+    rhythm = lock.get('page_rhythm', {})
+    if not rhythm:
+        report.warn('spec-lock',
+                    '[page_rhythm] missing — executor defaults every page to '
+                    'dense (the "every page looks the same" look)')
+    elif page_count is not None and len(rhythm) != page_count:
+        report.warn('spec-lock',
+                    f'[page_rhythm] has {len(rhythm)} entries but deck plan '
+                    f'has {page_count} slides')
+    icons = lock.get('icons', {})
+    if icons.get('library'):
+        report.ok('spec-lock',
+                  f"icon library declared: {icons['library']}")
+
+
+def check_icons(project: Path, report: Report) -> None:
+    svg_dir = project / 'svg_output'
+    if not svg_dir.is_dir():
+        return
+    try:
+        from svg_finalize.embed_icons import resolve_icon_path
+    except ImportError:
+        report.warn('icons', 'embed_icons unavailable — check skipped')
+        return
+    icons_dir = REPO_ROOT / 'templates' / 'icons'
+    refs: dict[str, set[str]] = {}
+    for svg in sorted(svg_dir.glob('*.svg')):
+        text = svg.read_text(encoding='utf-8', errors='replace')
+        for name in re.findall(r'data-icon="([^"]+)"', text):
+            refs.setdefault(name, set()).add(svg.name)
+    if not refs:
+        report.ok('icons', 'no icon references')
+        return
+    missing = {n for n in refs
+               if not resolve_icon_path(n, icons_dir)[0].exists()}
+    libs_used = {n.split('/', 1)[0] for n in refs if '/' in n}
+    for name in sorted(missing):
+        users = sorted(refs[name])
+        report.error('icons',
+                     f'{name} missing on disk (used in {", ".join(users[:3])}'
+                     f'{"…" if len(users) > 3 else ""}) — export would fail')
+    if not missing:
+        report.ok('icons', f'{len(refs)} distinct refs all resolve')
+    declared = None
+    lock_path = project / 'spec_lock.md'
+    if lock_path.exists():
+        try:
+            from update_spec import parse_lock
+            declared = parse_lock(lock_path).get('icons', {}).get('library')
+        except Exception:
+            pass
+    if declared and len(libs_used) == 1 and libs_used != {declared}:
+        report.warn('icons',
+                    f'spec_lock declares library "{declared}" but refs use '
+                    f'"{next(iter(libs_used))}" — one-library rule violated')
+
+
+def check_svg_quality(project: Path, report: Report) -> None:
+    svg_dir = project / 'svg_output'
+    if not svg_dir.is_dir():
+        return
+    try:
+        from svg_quality_checker import SVGQualityChecker
+    except ImportError:
+        report.warn('svg-quality', 'checker unavailable — check skipped')
+        return
+    checker = SVGQualityChecker()
+    error_files = []
+    for svg in sorted(svg_dir.glob('*.svg')):
+        result = checker.check_file(str(svg))
+        if not result['passed']:
+            error_files.append((result['file'], result['errors'][:2]))
+    if error_files:
+        for name, errors in error_files:
+            report.error('svg-quality', f'{name}: {errors[0]}')
+    else:
+        report.ok('svg-quality',
+                  f'{checker.summary["total"]} SVG file(s), 0 errors')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='EasySlides project doctor.')
+    parser.add_argument('project', help='Project directory path.')
+    parser.add_argument('--json', action='store_true', dest='as_json',
+                        help='Machine-readable report.')
+    args = parser.parse_args()
+
+    project = Path(args.project).resolve()
+    if not project.exists():
+        print(f"[ERROR] project not found: {project}")
+        sys.exit(1)
+
+    report = Report()
+    report.ok('project', str(project))
+    check_structure(project, report)
+    check_clarification(project, report)
+    page_count = check_deck_plan(project, report)
+    check_spec_lock(project, report, page_count)
+    check_icons(project, report)
+    check_svg_quality(project, report)
+
+    if args.as_json:
+        print(json.dumps(
+            {'project': str(project),
+             'rows': [{'level': lv, 'check': ck, 'detail': dt}
+                      for lv, ck, dt in report.rows]},
+            ensure_ascii=False, indent=2))
+    else:
+        report.print()
+    sys.exit(1 if report.has_errors else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/svg_finalize/embed_icons.py
+++ b/scripts/svg_finalize/embed_icons.py
@@ -138,6 +138,30 @@ def resolve_icon_path(icon_name: str, icons_dir: Path) -> tuple[Path, float]:
     return icon_path, base_size
 
 
+def find_missing_icon_refs(svg_content: str, icons_dir: Path) -> list[str]:
+    """
+    Return data-icon references whose icon file does not exist on disk.
+
+    Scans ``<use data-icon="library/name" ...>`` placeholders and resolves
+    each through :func:`resolve_icon_path`. Export (svg_to_pptx) hard-fails
+    on unreplaced ``<use>`` elements, so a missing file here means the deck
+    cannot be exported — callers should treat this as an error, not a hint.
+
+    Returns a de-duplicated list of the original (unresolved) icon names.
+    """
+    missing: list[str] = []
+    seen: set[str] = set()
+    for match in re.finditer(r'data-icon="([^"]+)"', svg_content):
+        icon_name = match.group(1).strip()
+        if not icon_name or icon_name in seen:
+            continue
+        seen.add(icon_name)
+        icon_path, _base = resolve_icon_path(icon_name, icons_dir)
+        if not icon_path.exists():
+            missing.append(icon_name)
+    return missing
+
+
 def extract_paths_from_icon(icon_path: Path, target_color: str = '#000000') -> tuple[list[str], str, float]:
     """
     Extract drawable elements from an icon SVG file.

--- a/scripts/svg_quality_checker.py
+++ b/scripts/svg_quality_checker.py
@@ -37,6 +37,56 @@ except ImportError:
     _parse_spec_lock = None  # spec_lock drift check will be skipped
 
 try:
+    from svg_finalize.embed_icons import find_missing_icon_refs as _find_missing_icon_refs
+except ImportError:
+    _find_missing_icon_refs = None  # icon preflight check will be skipped
+
+# Icons live in the repo's templates/icons directory regardless of which
+# project is being checked.
+_ICONS_DIR = Path(__file__).resolve().parent.parent / 'templates' / 'icons'
+
+
+def _decode_svg_entities(value: str) -> str:
+    """Decode the handful of XML entities SVG authors must escape.
+
+    Attribute values read as raw text still contain entities such as
+    ``&quot;`` (font-family stacks quote their family names). Comparisons
+    against spec_lock values — which hold the decoded characters — must run
+    on the decoded form, otherwise every quoted font stack drifts.
+    """
+    return (
+        value.replace('&quot;', '"')
+        .replace('&apos;', "'")
+        .replace('&lt;', '<')
+        .replace('&gt;', '>')
+        .replace('&amp;', '&')
+    )
+
+
+def _estimate_text_width_px(line: str, font_size: float) -> float:
+    """Cheap single-line width estimate in px.
+
+    CJK/fullwidth glyphs occupy ~1.0em; Latin digits ~0.6em; lowercase
+    ~0.5em; spaces ~0.3em; other punctuation ~0.45em. Deliberately crude —
+    the check is a warning-level tripwire for overflowing lines, not type
+    metrics.
+    """
+    width = 0.0
+    for ch in line:
+        code = ord(ch)
+        if code >= 0x2E80 or ch in '　，。：；！？、“”‘’（）《》【】':
+            width += font_size
+        elif ch == ' ':
+            width += font_size * 0.3
+        elif ch.isdigit() or ch.isupper():
+            width += font_size * 0.62
+        elif ch.islower():
+            width += font_size * 0.5
+        else:
+            width += font_size * 0.45
+    return width
+
+try:
     from svg_to_pptx.animation_config import (
         load_animation_config as _load_animation_config,
         validate_animation_config as _validate_animation_config,
@@ -259,6 +309,19 @@ class SVGQualityChecker:
                 #    image_sources.json; skip in template mode.
                 if not self.template_mode:
                     self._check_sourced_image_attribution(content, svg_path, result)
+
+                # 10. Check icon references against the on-disk library.
+                #     Unresolvable icons survive finalize as <use> placeholders
+                #     and hard-fail PPTX export, so this is an error, not a hint.
+                if not self.template_mode and _find_missing_icon_refs is not None:
+                    self._check_icon_references(content, result)
+
+                # 11. Warning-level text-overflow tripwire (CJK-aware width
+                #     estimate). Free-design pages have no slot capacity
+                #     contract, so this is the only early defense against
+                #     overflowing/overlapping single-line text.
+                if not self.template_mode:
+                    self._check_text_overflow(content, svg_path, result)
 
             # Determine pass/fail
             result['passed'] = len(result['errors']) == 0
@@ -626,6 +689,94 @@ class SVGQualityChecker:
                 return data
         return None
 
+    def _check_icon_references(self, content: str, result: Dict, icons_dir: Path = None):
+        """Error on <use data-icon="..."> refs whose icon file is missing.
+
+        finalize_svg leaves unresolved placeholders in place and PPTX export
+        then aborts with SvgNativeConversionError — catching this here moves
+        the failure to check time with a per-file, per-icon report.
+        """
+        if _find_missing_icon_refs is None:
+            return
+        base = icons_dir or _ICONS_DIR
+        for icon_name in _find_missing_icon_refs(content, base):
+            result['errors'].append(
+                f"Icon not found in library: {icon_name} "
+                f"(resolved under {base}) — PPTX export would fail; "
+                f"fix the name, switch the library in spec_lock.md, or run "
+                f"scripts/icon_inventory.py fetch"
+            )
+
+    def _check_text_overflow(self, content: str, svg_path: Path, result: Dict):
+        """Warn when a single logical text line likely overflows the canvas.
+
+        Free-design pages carry no slot capacity contract; this CJK-aware
+        width estimate is a tripwire, not a typesetter. Warn-level by design.
+        """
+        try:
+            root = ET.fromstring(content)
+        except ET.ParseError:
+            return  # well-formedness already reported by check 0
+
+        ns = '{http://www.w3.org/2000/svg}'
+        vb_match = re.search(r'viewBox="0\s+0\s+([\d.]+)\s+([\d.]+)"', content)
+        canvas_w = float(vb_match.group(1)) if vb_match else 1280.0
+        edge = canvas_w - 40.0  # 40px safe margin
+
+        def _lines(elem):
+            """Yield (x, anchor, font_size, text) per logical line."""
+            fs_raw = elem.get('font-size')
+            try:
+                fs = float(fs_raw) if fs_raw else None
+            except ValueError:
+                fs = None
+            anchor = elem.get('text-anchor', 'start')
+            line_tspans = [
+                t for t in elem.findall(f'{ns}tspan')
+                if t.get('x') is not None or t.get('dy') is not None
+            ]
+            if line_tspans:
+                head = (elem.text or '').strip()
+                if head:
+                    yield elem.get('x'), anchor, fs, head
+                for t in line_tspans:
+                    t_fs_raw = t.get('font-size')
+                    try:
+                        t_fs = float(t_fs_raw) if t_fs_raw else fs
+                    except ValueError:
+                        t_fs = fs
+                    yield (
+                        t.get('x'),
+                        t.get('text-anchor', anchor),
+                        t_fs,
+                        ''.join(t.itertext()),
+                    )
+            else:
+                yield elem.get('x'), anchor, fs, ''.join(elem.itertext())
+
+        for elem in root.iter(f'{ns}text'):
+            for x, anchor, fs, line in _lines(elem):
+                if not line.strip() or fs is None or x is None:
+                    continue  # unsizeable (inherited size) — leave to render QA
+                try:
+                    x_val = float(x)
+                except ValueError:
+                    continue
+                width = _estimate_text_width_px(line, fs)
+                if anchor == 'middle':
+                    left, right = x_val - width / 2, x_val + width / 2
+                elif anchor == 'end':
+                    left, right = x_val - width, x_val
+                else:
+                    left, right = x_val, x_val + width
+                if right > edge + 4 or left < -4:
+                    snippet = line.strip()[:24]
+                    result['warnings'].append(
+                        f"Possible text overflow: '{snippet}…' ~{width:.0f}px "
+                        f"@{fs:.0f}px spans [{left:.0f},{right:.0f}] vs canvas "
+                        f"{canvas_w:.0f}px (safe <={edge:.0f})"
+                    )
+
     def _check_spec_lock_drift(self, content: str, svg_path: Path, result: Dict):
         """Detect values used in the SVG that fall outside spec_lock.md.
 
@@ -689,8 +840,12 @@ class SVGQualityChecker:
         font_drifts = set()
         for m in re.finditer(r'font-family\s*=\s*["\']([^"\']+)["\']', content):
             val = m.group(1).strip()
-            if allowed_fonts and val not in allowed_fonts:
-                font_drifts.add(val)
+            # Attribute values read as raw text keep XML entities (&quot;…)
+            # while spec_lock holds decoded characters — compare on the
+            # decoded form to avoid flagging every quoted font stack.
+            val_decoded = _decode_svg_entities(val)
+            if allowed_fonts and val_decoded not in allowed_fonts and val not in allowed_fonts:
+                font_drifts.add(val_decoded)
 
         size_drifts = set()
         for m in re.finditer(r'font-size\s*=\s*["\']([^"\']+)["\']', content):

--- a/scripts/svg_to_pptx/pptx_builder.py
+++ b/scripts/svg_to_pptx/pptx_builder.py
@@ -531,6 +531,10 @@ def create_pptx_with_native_svg(
         narration_slides_created: set[int] = set()
         audio_exts_used: set[str] = set()
         mixed_animation_offset = 0
+        # Native mode collects per-page failures and keeps converting the
+        # remaining slides, so one bad page surfaces every other bad page in
+        # a single run instead of one round-trip per fix.
+        native_failures: list[tuple[int, str, str]] = []
 
         for i, svg_path in enumerate(svg_files, 1):
             slide_num = i
@@ -831,9 +835,29 @@ def create_pptx_with_native_svg(
                 if verbose:
                     print(f"  [{i}/{len(svg_files)}] {svg_path.name} - Error: {e}")
                 if use_native_shapes:
-                    raise
+                    # Collect and continue: aborting on the first failure
+                    # hides every other broken page behind a fix-rerun loop.
+                    native_failures.append((i, svg_path.name, str(e)))
 
         # Update [Content_Types].xml
+        if native_failures:
+            # Never write a partial deck. Summarize every failed page — with
+            # the offending elements the converter named — then abort.
+            print()
+            print(f"[ERROR] Native conversion failed on {len(native_failures)} "
+                  f"of {len(svg_files)} page(s); no PPTX written:")
+            for page_num, name, message in native_failures:
+                print(f"  page {page_num:02d}  {name}")
+                print(f"          {message}")
+            print()
+            print("  Hint: run scripts/svg_quality_checker.py <project> — the "
+                  "icon preflight catches the most common cause (missing icon "
+                  "files) before export.")
+            raise RuntimeError(
+                f"native conversion failed on {len(native_failures)} page(s): "
+                + "; ".join(f"p{num} {name}" for num, name, _ in native_failures)
+            )
+
         content_types_path = extract_dir / '[Content_Types].xml'
         with open(content_types_path, 'r', encoding='utf-8') as f:
             content_types = f.read()

--- a/scripts/visual_review.py
+++ b/scripts/visual_review.py
@@ -79,8 +79,10 @@ def _stage_slide_images(image_files: list[Path], output: Path) -> list[Path]:
     slides_dir = output / "slides"
     slides_dir.mkdir(parents=True, exist_ok=True)
     staged: list[Path] = []
-    for index, source in enumerate(image_files, start=1):
-        target = slides_dir / f"slide_{index:03d}.png"
+    for source in image_files:
+        # Keep the source page number so a filtered review (e.g. --slides 8)
+        # still refers to the deck's real slide numbers, not a re-numbered 1..N.
+        target = slides_dir / f"slide_{_slide_number(source):03d}.png"
         if source.resolve() != target.resolve():
             shutil.copy2(source, target)
         staged.append(target)
@@ -141,6 +143,7 @@ def build_review_package(
     skip_render: bool = False,
     dpi: int = 144,
     title: str | None = None,
+    only_pages: set[int] | None = None,
 ) -> dict[str, Any]:
     pptx = Path(pptx_path).resolve()
     output = Path(output_dir).resolve()
@@ -160,6 +163,11 @@ def build_review_package(
         }
 
     image_files = rendered_pngs(slides_dir)
+    if only_pages:
+        image_files = [
+            path for path in image_files
+            if _slide_number(path) in only_pages
+        ]
     if not image_files:
         raise ValueError(f"no rendered slide PNGs found: {slides_dir}")
     image_files = _stage_slide_images(image_files, output)
@@ -178,11 +186,11 @@ def build_review_package(
         "html": "index.html",
         "slides": [
             {
-                "slide": index,
+                "slide": _slide_number(path),
                 "image": path.relative_to(output).as_posix(),
                 "checks": ["readable", "aligned", "complete"],
             }
-            for index, path in enumerate(image_files, start=1)
+            for path in image_files
         ],
     }
     (output / "visual_review.json").write_text(
@@ -200,9 +208,33 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--rendered-dir", help="Use an existing rendered PNG directory.")
     parser.add_argument("--skip-render", action="store_true", help="Do not render; require --rendered-dir or existing --out/slides PNGs.")
     parser.add_argument("--dpi", type=int, default=144)
+    parser.add_argument("--slides", help=(
+        "Comma-separated 1-based slide numbers to keep in the review package, "
+        "e.g. --slides 1,8,14. Rendering still processes the whole deck "
+        "(the backend converts the file as a whole); the filter limits which "
+        "slides enter the manifest, contact sheet, and HTML — useful for "
+        "re-reviewing just the pages you fixed against --rendered-dir."
+    ))
     parser.add_argument("--title")
     parser.add_argument("--quiet", action="store_true")
     return parser
+
+
+def parse_slide_filter(spec: str | None) -> set[int] | None:
+    """'1,8-10' -> {1, 8, 9, 10}; None when no filter given."""
+    if not spec:
+        return None
+    pages: set[int] = set()
+    for part in spec.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        if '-' in part:
+            lo, _, hi = part.partition('-')
+            pages.update(range(int(lo), int(hi) + 1))
+        else:
+            pages.add(int(part))
+    return pages or None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -215,6 +247,7 @@ def main(argv: list[str] | None = None) -> int:
             skip_render=args.skip_render,
             dpi=args.dpi,
             title=args.title,
+            only_pages=parse_slide_filter(args.slides),
         )
     except Exception as exc:
         if not args.quiet:

--- a/tests/test_pipeline_hardening.py
+++ b/tests/test_pipeline_hardening.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+"""Tests for the pipeline hardening changes (branch fix/pipeline-hardening).
+
+Covers:
+- icon preflight: find_missing_icon_refs + checker integration
+- font entity normalization in spec_lock drift comparison
+- CJK-aware text overflow estimation
+- slide filter parsing in visual_review
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / 'scripts'))
+
+from svg_quality_checker import (  # noqa: E402
+    SVGQualityChecker,
+    _decode_svg_entities,
+    _estimate_text_width_px,
+)
+from svg_finalize.embed_icons import find_missing_icon_refs  # noqa: E402
+
+
+# ---------------------------------------------------------------- helpers
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding='utf-8')
+    return path
+
+
+SVG_TMPL = (
+    '<svg width="1280" height="720" viewBox="0 0 1280 720" '
+    'xmlns="http://www.w3.org/2000/svg">{body}</svg>'
+)
+
+LOCK_OK = (
+    '# Execution Lock\n'
+    '\n'
+    '## canvas\n'
+    '- viewBox: 0 0 1280 720\n'
+    '\n'
+    '## colors\n'
+    '- primary: #E8590C\n'
+    '\n'
+    '## typography\n'
+    '- font_family: "Microsoft YaHei", Arial, sans-serif\n'
+    '- body: 19\n'
+)
+
+
+# ---------------------------------------------------------------- entities
+
+def test_decode_svg_entities():
+    assert _decode_svg_entities('&quot;Microsoft YaHei&quot;, Arial') == \
+        '"Microsoft YaHei", Arial'
+    assert _decode_svg_entities('R&amp;D') == 'R&D'
+    assert _decode_svg_entities('plain') == 'plain'
+
+
+def test_font_drift_not_flagged_for_quoted_stack(tmp_path):
+    """The regression from the codex_orange_book_pitch run: quoted font
+    stacks written as &quot;…&quot; in SVG attributes must not drift against
+    a lock that holds the decoded characters."""
+    svg = _write(tmp_path / 'svg_output' / 'a.svg', SVG_TMPL.format(
+        body='<text x="10" y="20" font-size="19" '
+             'font-family="&quot;Microsoft YaHei&quot;, Arial, sans-serif" '
+             'fill="#E8590C">你好</text>'))
+    _write(tmp_path / 'spec_lock.md', LOCK_OK)
+    checker = SVGQualityChecker()
+    result = checker.check_file(str(svg))
+    assert result['passed']
+    drift = [w for w in result['warnings'] if 'font' in w.lower()
+             and 'drift' in w.lower()]
+    assert not drift, drift
+
+
+# ---------------------------------------------------------------- icons
+
+def test_find_missing_icon_refs(tmp_path):
+    lib = tmp_path / 'icons' / 'tabler-outline'
+    lib.mkdir(parents=True)
+    (lib / 'rocket.svg').write_text('<svg></svg>', encoding='utf-8')
+    svg = (
+        '<svg><use data-icon="tabler-outline/rocket"/>'
+        '<use data-icon="tabler-outline/nope"/></svg>'
+    )
+    missing = find_missing_icon_refs(svg, tmp_path / 'icons')
+    assert missing == ['tabler-outline/nope']
+
+
+def test_checker_errors_on_missing_icon(tmp_path):
+    svg = _write(tmp_path / 'svg_output' / 'a.svg', SVG_TMPL.format(
+        body='<use data-icon="tabler-outline/definitely-not-here"/>'))
+    _write(tmp_path / 'spec_lock.md', LOCK_OK)
+    checker = SVGQualityChecker()
+    result = checker.check_file(str(svg))
+    assert not result['passed']
+    assert any('Icon not found in library' in e for e in result['errors'])
+
+
+# ---------------------------------------------------------------- overflow
+
+def test_width_estimator_cjk_vs_latin():
+    cjk = _estimate_text_width_px('你好世界', 20)
+    latin = _estimate_text_width_px('HELLO', 20)
+    assert cjk == 4 * 20          # full-width glyphs
+    assert latin == 5 * 20 * 0.62  # uppercase latin
+
+
+def test_checker_warns_on_overflowing_line(tmp_path):
+    long_line = '这是一段非常长的中文文本' * 20  # ~840px at 21px
+    svg = _write(tmp_path / 'svg_output' / 'a.svg', SVG_TMPL.format(
+        body=f'<text x="1200" y="20" font-size="21" '
+             f'font-family="Arial, sans-serif" fill="#000000">'
+             f'{long_line}</text>'))
+    _write(tmp_path / 'spec_lock.md', LOCK_OK)
+    checker = SVGQualityChecker()
+    result = checker.check_file(str(svg))
+    assert any('Possible text overflow' in w for w in result['warnings'])
+    # warning must not fail the file
+    assert result['passed']
+
+
+def test_checker_quiet_on_fitting_line(tmp_path):
+    svg = _write(tmp_path / 'svg_output' / 'a.svg', SVG_TMPL.format(
+        body='<text x="60" y="20" font-size="19" '
+             'font-family="Arial, sans-serif" fill="#000000">短文本</text>'))
+    _write(tmp_path / 'spec_lock.md', LOCK_OK)
+    checker = SVGQualityChecker()
+    result = checker.check_file(str(svg))
+    assert not [w for w in result['warnings'] if 'overflow' in w]
+
+
+# ---------------------------------------------------------------- slides
+
+def test_parse_slide_filter():
+    from visual_review import parse_slide_filter
+    assert parse_slide_filter(None) is None
+    assert parse_slide_filter('') is None
+    assert parse_slide_filter('1,8,14') == {1, 8, 14}
+    assert parse_slide_filter('8-10') == {8, 9, 10}
+    assert parse_slide_filter('1, 8-10') == {1, 8, 9, 10}


### PR DESCRIPTION
## 背景

用本仓库完整生成一份 24 页真实 PPT（ChatGPT 橙皮书宣讲）时暴露的五个工程问题。全部修复均来自踩坑实录，并已在真实项目上端到端验证。

## 修复清单

### 1. 图标 preflight 门（三层拦截）
本次唯一的硬失败：仓库 `templates/icons/lucide/` 只带 4 个 SVG，而 `icons_manifest.js` 声明了 9835 个（gap 已量化）。Executor 按文档默认使用 lucide → `finalize_svg.py` 只打 WARN 即放行 → `svg_to_pptx.py` 导出时才抛 `SvgNativeConversionError`，且逐页挤牙膏式暴露。

- `embed_icons.py`：新增 `find_missing_icon_refs()`
- `svg_quality_checker.py` 新增检查 10：引用解析不到磁盘文件即 error（导出本就会硬失败）
- `finalize_svg.py`：残留占位符逐文件列出并 exit 1
- 新增 `scripts/icon_inventory.py`：`stats` / `missing` / `fetch`（lucide CDN 按需拉取）

### 2. 检查器准确性
- spec_lock 字体漂移比对前解码 XML 实体：`&quot;Microsoft YaHei&quot;` 不再全体误报（实测 24 文件误报 → 0）
- 新增检查 11：CJK 感知的单行文本溢出 tripwire（全宽 1.0em / 大写 0.62 / 小写 0.5em），free-design 页面在渲染前就能抓住卡片文字重叠

### 3. 导出批量错误报告
原生模式收集所有失败页继续转换，最后一次性汇总（页号+违规元素）再中止，不写任何输出文件。替代原来"修一页重跑一轮"的循环。

### 4. `scripts/project_doctor.py`
一站式只读体检：结构 / 澄清确认 / deck_plan 契约 / spec_lock 完整性（含 body 基线、page_rhythm 覆盖）/ 图标解析与单库一致性 / SVG 质量。人话输出，支持 `--json`。

### 5. `visual_review --slides 8,14`
复查包过滤：配合 `--rendered-dir` 只复查改过的页，staged 文件与 manifest 保留真实页号。

## 验证

- `tests/test_pipeline_hardening.py`：8 用例全过
- 相关既有套件（checker 模板模式 / 图标库 / 图标画廊）：16 全过；触及区域回归 10 全过
- 破坏性端到端：注入坏图标 → checker 检查期报错 → finalize exit 1 → 导出批量汇总且零文件写出；修复后 24/24 正常导出
- 真实项目（24 页橙色主题宣讲 PPT）：checker 24/24 fully passed、0 警告；doctor PASS