### PR TITLE
feat: ZCode plugin manifest and marketplace listing

### DIFF
--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "easyslides",
+  "version": "1.0.0+zcode.20260827000000",
+  "description": "EasySlides creates editable academic PPTX decks and distills source PowerPoint files into content-free semantic templates, components, and symbols with fail-closed visual QA.",
+  "author": {
+    "name": "EasySlides contributors"
+  },
+  "license": "MIT",
+  "keywords": [
+    "PowerPoint",
+    "PPTX",
+    "academic presentations",
+    "research presentations",
+    "editable slides",
+    "PPTX distillation",
+    "template extraction",
+    "EasySlides",
+    "蒸馏PPT",
+    "PPT模板",
+    "答辩PPT"
+  ],
+  "skills": "./skills/"
+}

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "easyslides",
       "source": "./",
-      "icon": "https://raw.githubusercontent.com/Rimagination/easyslides/main/assets/easyslides-icon.png",
+      "icon": "https://raw.githubusercontent.com/Rimagination/easyslides/main/assets/icon.png",
       "description": "Create, distill, edit, review, and export editable academic PPTX presentations (生成PPT、蒸馏PPT、复用模板、答辩PPT) with an SVG-to-DrawingML pipeline and fail-closed visual QA.",
       "version": "1.0.0",
       "author": {

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,30 @@
+{
+  "name": "easyslides",
+  "description": "EasySlides plugin marketplace: editable academic PPTX generation, template distillation, and visual QA for ZCode.",
+  "owner": {
+    "name": "Rimagination"
+  },
+  "plugins": [
+    {
+      "name": "easyslides",
+      "source": "./",
+      "icon": "https://raw.githubusercontent.com/Rimagination/easyslides/main/assets/easyslides-icon.png",
+      "description": "Create, distill, edit, review, and export editable academic PPTX presentations (生成PPT、蒸馏PPT、复用模板、答辩PPT) with an SVG-to-DrawingML pipeline and fail-closed visual QA.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Rimagination"
+      },
+      "category": "productivity",
+      "keywords": [
+        "pptx",
+        "powerpoint",
+        "academic",
+        "presentation",
+        "template",
+        "蒸馏PPT",
+        "答辩PPT"
+      ],
+      "homepage": "https://github.com/Rimagination/easyslides"
+    }
+  ]
+}


### PR DESCRIPTION
## 内容

让 EasySlides 可通过 ZCode 客户端的「添加插件市场」一键安装（GitHub 仓库或本地目录两种方式）。

- **`marketplace.json`**（仓库根）：ZCode 定位市场清单的路径是 `./marketplace.json` 或 `.claude-plugin/marketplace.json`（见客户端 `findMarketplaceManifestPath`），本清单声明 easyslides 插件（source 指向仓库根）
- **`.zcode-plugin/plugin.json`**：插件清单，挂载 `skills/easyslides` 技能适配器（`.claude-plugin/`、`.codex-plugin/` 为等效兼容目录名）

## 图标

使用 `assets/icon.png`（当前黑白版 logo，256×256）的 raw GitHub URL。实测结论：

- raw.githubusercontent 的 **PNG URL 在 ZCode 市场界面正常渲染**（红色旧版 icon 曾成功显示）
- SVG 的 **data URI 不渲染**（整个图标区域消失），故不用
- `easyslides-icon.png` 是旧版红色 logo，不采用

## 验证

- ZCode 客户端实测：添加本地目录市场 → 市场与插件正常列出（技能 easyslides / easyslides-clarify / easyslides-distill 均识别）
- 两份 JSON 均通过语法与字段校验
- 合并后任何用户在 ZCode「添加插件市场」填 `Rimagination/easyslides` 即可安装